### PR TITLE
Add option for sshconfig

### DIFF
--- a/library/ale_aos_command.py
+++ b/library/ale_aos_command.py
@@ -50,6 +50,11 @@ options:
             - SSH connection port
         required: false
         default: 22
+    sshconf:
+        description:
+            - Path to sshconfig to use for connections
+        required: false
+        default: None
     username:
         description:
             - Login username
@@ -80,6 +85,7 @@ EXAMPLES = '''
     host: "{{ inventory_hostname }}"
     username: admin
     password: switch
+    sshconf: ~/.ssh/config
     command: show running-directory
     search: "Running Configuration    : SYNCHRONIZED"
 '''

--- a/library/ale_aos_command.py
+++ b/library/ale_aos_command.py
@@ -105,6 +105,7 @@ def main():
         argument_spec=dict(
             host=dict(type=str, equired=True),
             port=dict(type=int, required=False, default=22),
+            sshconfig=dict(type=str, required=False, default=None),
             username=dict(type=str, required=True),
             password=dict(type=str, required=True, no_log=True),
             command=dict(type=str, required=True),
@@ -117,6 +118,7 @@ def main():
         'device_type': 'alcatel_aos',
         'ip': module.params['host'],
         'port': module.params['port'],
+        'ssh_config_file': module.params['sshconfig'],
         'username': module.params['username'],
         'password': module.params['password'],
     }

--- a/library/ale_aos_config.py
+++ b/library/ale_aos_config.py
@@ -141,6 +141,7 @@ def main():
         argument_spec=dict(
             host=dict(type=str, required=True),
             port=dict(type=int, required=False, default=22),
+            sshconfig=dict(type=str, required=False, default=None),
             username=dict(type=str, required=True),
             password=dict(type=str, required=True, no_log=True),
             file=dict(type=str, required=False, default=None),
@@ -154,6 +155,7 @@ def main():
         'device_type': 'alcatel_aos',
         'ip': module.params['host'],
         'port': module.params['port'],
+        'ssh_config_file': module.params['sshconfig'],
         'username': module.params['username'],
         'password': module.params['password'],
     }

--- a/library/ale_aos_config.py
+++ b/library/ale_aos_config.py
@@ -50,6 +50,11 @@ options:
             - SSH connection port
         required: false
         default: 22
+    sshconf:
+        description:
+            - Path to sshconfig to use for connections
+        required: false
+        default: None
     username:
         description:
             - Login username
@@ -85,6 +90,7 @@ EXAMPLES = '''
     host: "{{ inventory_hostname }}"
     username: admin
     password: switch
+    sshconf: ~/.ssh/config
     commands:
       - vlan 100 enable name test1
       - vlan 200 enable name test2

--- a/library/ale_aos_ping.py
+++ b/library/ale_aos_ping.py
@@ -95,6 +95,7 @@ def main():
         argument_spec=dict(
             host=dict(type=str, required=True),
             port=dict(type=int, required=False, default=22),
+            sshconfig=dict(type=str, required=False, default=None),
             username=dict(type=str, required=True),
             password=dict(type=str, required=True, no_log=True),
             check_string=dict(type=str, required=False, default='>'),
@@ -105,6 +106,7 @@ def main():
         'device_type': 'alcatel_aos',
         'ip': module.params['host'],
         'port': module.params['port'],
+        'ssh_config_file': module.params['sshconfig'],
         'username': module.params['username'],
         'password': module.params['password'],
         'timeout': 10,

--- a/library/ale_aos_ping.py
+++ b/library/ale_aos_ping.py
@@ -50,6 +50,11 @@ options:
             - SSH connection port
         required: false
         default: 22
+    sshconf:
+        description:
+            - Path to sshconfig to use for connections
+        required: false
+        default: None
     username:
         description:
             - Login username
@@ -70,6 +75,7 @@ EXAMPLES = '''
     host: "{{ inventory_hostname }}"
     username: admin
     password: switch
+    sshconf: ~/.ssh/config
 '''
 
 RETURN = '''


### PR DESCRIPTION
This PR adds the option `sshconfig` which could be set to a path pointing to the SSH config file used by the user.
One usecase for this is to define jump hosts in the ssh config which will be followed by netmiko, so it's also possible to use this role with switches/routers which are not directly reachable from the device Ansible is run on.